### PR TITLE
Classpath libraries are not correctly added to docker container

### DIFF
--- a/src/main/scala/sbtdocker/Plugin.scala
+++ b/src/main/scala/sbtdocker/Plugin.scala
@@ -62,7 +62,7 @@ object Plugin extends sbt.Plugin {
       }
 
       val appPath = "/app"
-      val libsPath = s"$appPath/libs"
+      val libsPath = s"$appPath/libs/"
       val jarPath = s"$appPath/${jar.name}"
 
       val libFiles = classpath.files.map(libFile => StageFile(libFile, libsPath))


### PR DESCRIPTION
There seems to be an error in the `libsPath` in `packageDockerSettings`. The path for the added libraries should be expanded using the filename which is only done when the target path ends in a `/`. After adding the slash to the `libsPath` the container generation seems to run okay.
