### PR TITLE
preserveLastModified on dependencies. improves image caching

### DIFF
--- a/src/main/scala/sbtdocker/staging/SourceFile.scala
+++ b/src/main/scala/sbtdocker/staging/SourceFile.scala
@@ -13,9 +13,9 @@ case class CopyFile(file: File) extends SourceFile {
 
   def stage(destination: File) = {
     if (file.isDirectory) {
-      IO.copyDirectory(file, destination)
+      IO.copyDirectory(file, destination, preserveLastModified = true)
     } else {
-      IO.copyFile(file, destination)
+      IO.copyFile(file, destination, preserveLastModified = true)
     }
   }
 }


### PR DESCRIPTION
This changeset makes dependencies copying with preserving lastModified date, which makes docker cache working while building/pushing/pulling image layers.

The process becomes faster and less data need to be transferred if dependencies stay the same