### PR TITLE
Dynamically remove the image tag '-f' flag when running with Docker 1.10 or greater

### DIFF
--- a/src/main/scala/sbtdocker/DockerTag.scala
+++ b/src/main/scala/sbtdocker/DockerTag.scala
@@ -1,6 +1,5 @@
 package sbtdocker
 
-
 import sbt.Logger
 
 import sys.process.{Process, ProcessLogger}
@@ -14,7 +13,11 @@ object DockerTag {
     })
 
     log.info(s"Tagging image $id with name: $name")
-    val command = dockerPath :: "tag" :: "-f" :: id.id :: name.toString :: Nil
+
+    val version = DockerVersion(dockerPath, log)
+    val flags = if(version.major <= 1 && version.minor < 10) "-f" :: Nil else Nil
+    val command = dockerPath :: "tag" :: flags ::: id.id :: name.toString :: Nil
+
     val processOutput = Process(command).lines(processLogger)
     processOutput.foreach { line =>
       log.info(line)

--- a/src/main/scala/sbtdocker/DockerVersion.scala
+++ b/src/main/scala/sbtdocker/DockerVersion.scala
@@ -1,0 +1,39 @@
+package sbtdocker
+
+import sbt.Logger
+
+import sys.process.{Process, ProcessLogger}
+import scala.util.parsing.combinator.RegexParsers
+
+case class DockerVersion(major: Int, minor: Int, release: Int)
+
+object DockerVersion extends RegexParsers {
+  def apply(dockerPath: String, log: Logger): DockerVersion = {
+    val processLogger = ProcessLogger({ line =>
+      log.info(line)
+    }, { line =>
+      log.info(line)
+    })
+
+    val command = dockerPath :: "version" :: "-f" :: "{{.Server.Version}}" :: Nil
+    val processOutput = Process(command).!!(processLogger)
+    parseVersion(processOutput)
+  }
+
+  def parseVersion(version: String): DockerVersion = {
+    parse(parser, version) match {
+      case Success(ver, _) => ver
+      case NoSuccess(msg, _) => throw new RuntimeException(s"Could not parse Version from $version: $msg")
+    }
+  }
+
+  private val positiveWholeNumber: Parser[Int] = {
+    ("0".r | """[1-9]?\d*""".r).map(_.toInt).withFailureMessage("non-negative integer value expected")
+  }
+
+  private val parser: Parser[DockerVersion] = {
+    positiveWholeNumber ~ ("." ~> positiveWholeNumber) ~ ("." ~> positiveWholeNumber) ^^ {
+      case major ~ minor ~ release  => DockerVersion(major, minor, release)
+    }
+  }
+}

--- a/src/test/scala/sbtdocker/DockerVersionSpec.scala
+++ b/src/test/scala/sbtdocker/DockerVersionSpec.scala
@@ -1,0 +1,31 @@
+package sbtdocker
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class DockerVersionSpec extends FlatSpec with Matchers {
+  it should "correctly parse" in {
+    DockerVersion.parseVersion("1.0.0") shouldEqual DockerVersion(1,0,0)
+    DockerVersion.parseVersion("11.1.1") shouldEqual DockerVersion(11,1,1)
+    DockerVersion.parseVersion("1.0.0-SNAPSHOT") shouldEqual DockerVersion(1,0,0)
+    DockerVersion.parseVersion("1.2.3") shouldEqual DockerVersion(1,2,3)
+    DockerVersion.parseVersion("1.2.3-rc3") shouldEqual DockerVersion(1,2,3)
+  }
+
+  it should "not parse" in {
+    intercept[RuntimeException] {
+      DockerVersion.parseVersion("")
+    }
+
+    intercept[RuntimeException] {
+      DockerVersion.parseVersion("1.0")
+    }
+
+    intercept[RuntimeException] {
+      DockerVersion.parseVersion("-1.0")
+    }
+
+    intercept[RuntimeException] {
+      DockerVersion.parseVersion("version")
+    }
+  }
+}


### PR DESCRIPTION
Docker is removing the `'-f'` flag from the `'tag'` command in v1.12. It was deprecated as of v1.10. This pull request checks the version of Docker being used and will not include the `'-f'` flag when calling `'docker tag'` starting with version v1.10.