### PR TITLE
Minor update to Tag version check

### DIFF
--- a/src/main/scala/sbtdocker/DockerTag.scala
+++ b/src/main/scala/sbtdocker/DockerTag.scala
@@ -15,7 +15,7 @@ object DockerTag {
     log.info(s"Tagging image $id with name: $name")
 
     val version = DockerVersion(dockerPath, log)
-    val flags = if(version.major <= 1 && version.minor < 10) "-f" :: Nil else Nil
+    val flags = if(version.major < 1 || (version.major == 1 && version.minor < 10)) "-f" :: Nil else Nil
     val command = dockerPath :: "tag" :: flags ::: id.id :: name.toString :: Nil
 
     val processOutput = Process(command).lines(processLogger)


### PR DESCRIPTION
Minor update to version check to make sure that any one running on docker 0.10 or greater will still get the '-f' flag.