### PR TITLE
Update release naming convention

### DIFF
--- a/src/main/scala/sbtdocker/DockerVersion.scala
+++ b/src/main/scala/sbtdocker/DockerVersion.scala
@@ -28,7 +28,7 @@ object DockerVersion extends RegexParsers {
   }
 
   private val positiveWholeNumber: Parser[Int] = {
-    ("0".r | """[1-9]?\d*""".r).map(_.toInt).withFailureMessage("non-negative integer value expected")
+    """\d+""".r.map(_.toInt).withFailureMessage("non-negative integer value expected")
   }
 
   private val parser: Parser[DockerVersion] = {

--- a/src/test/scala/sbtdocker/DockerVersionSpec.scala
+++ b/src/test/scala/sbtdocker/DockerVersionSpec.scala
@@ -9,6 +9,7 @@ class DockerVersionSpec extends FlatSpec with Matchers {
     DockerVersion.parseVersion("1.0.0-SNAPSHOT") shouldEqual DockerVersion(1,0,0)
     DockerVersion.parseVersion("1.2.3") shouldEqual DockerVersion(1,2,3)
     DockerVersion.parseVersion("1.2.3-rc3") shouldEqual DockerVersion(1,2,3)
+    DockerVersion.parseVersion("17.03.0-ce") shouldEqual DockerVersion(17,3,0)
   }
 
   it should "not parse" in {


### PR DESCRIPTION
Starting with release "17.03.0-ce", Docker is on a monthly release cycle and uses a new YY.MM versioning scheme to reflect this.