### PR TITLE
Resolves marcuslonnberg/sbt-docker/issues/64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ jdk:
   - oraclejdk7
   - openjdk7
 before_install:
-  # Workaround for buffer overflow error in OpenJDK 7
+  - cat /etc/hosts # optionally check the content *before*
   - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts > /tmp/hosts
+  - sudo mv /tmp/hosts /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*

--- a/src/main/scala/sbtdocker/DockerVersion.scala
+++ b/src/main/scala/sbtdocker/DockerVersion.scala
@@ -32,7 +32,7 @@ object DockerVersion extends RegexParsers {
   }
 
   private val parser: Parser[DockerVersion] = {
-    positiveWholeNumber ~ ("." ~> positiveWholeNumber) ~ ("." ~> positiveWholeNumber) ^^ {
+    positiveWholeNumber ~ ("." ~> positiveWholeNumber) ~ ("." ~> positiveWholeNumber) <~ """.*""".r ^^ {
       case major ~ minor ~ release  => DockerVersion(major, minor, release)
     }
   }


### PR DESCRIPTION
New Docker version for OSX changes the version format, adding "-ce"
suffix to it. New version parser ignores that suffix for simplicity.