### PR TITLE
Fix openjdk7 buffer overflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ jdk:
   - oraclejdk8
   - oraclejdk7
   - openjdk7
-before_install:
-  # Workaround for buffer overflow error in OpenJDK 7
-  - sudo hostname "$(hostname | cut -c1-63)"
-  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+# Workaround for buffer overflow error in OpenJDK 7
+addons:
+  hosts:
+    - sbt-docker-ci
+  hostname: sbt-docker-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,13 @@ addons:
   hosts:
     - sbt-docker-ci
   hostname: sbt-docker-ci
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+
+before_cache:
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete


### PR DESCRIPTION
1. New walkaround for buffer overflow in OpenJDK 7.
2. Cache libraries and sbt in Travis CI.