### PR TITLE
replace deprecated "java" image with "openjdk:8-jre"

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ dockerfile in docker := {
   val artifactTargetPath = s"/app/${artifact.name}"
 
   new Dockerfile {
-    from("java")
+    from("openjdk:8-jre")
     add(artifact, artifactTargetPath)
     entryPoint("java", "-jar", artifactTargetPath)
   }
@@ -87,7 +87,7 @@ dockerfile in docker := {
   val targetDir = "/app"
 
   new Dockerfile {
-    from("java")
+    from("openjdk:8-jre")
     entryPoint(s"$targetDir/bin/${executableScriptName.value}")
     copy(appDir, targetDir, chown = "daemon:daemon")
   }
@@ -106,7 +106,7 @@ dockerfile in docker := {
     .mkString(":") + ":" + jarTarget
   new Dockerfile {
     // Base image
-    from("java")
+    from("openjdk:8-jre")
     // Add all files on the classpath
     add(classpath.files, "/app/")
     // Add the JAR file

--- a/examples/package-basic/build.sbt
+++ b/examples/package-basic/build.sbt
@@ -16,7 +16,7 @@ dockerfile in docker := {
   val classpathString = classpath.files.map("/app/" + _.getName).mkString(":") + ":" + jarTarget
   new Dockerfile {
     // Base image
-    from("java")
+    from("openjdk:8-jre")
     // Add all files on the classpath
     add(classpath.files, "/app/")
     // Add the JAR file

--- a/examples/package-spray/build.sbt
+++ b/examples/package-spray/build.sbt
@@ -25,7 +25,7 @@ dockerfile in docker := {
 
   new Dockerfile {
     // Use a base image that contain Java
-    from("java")
+    from("openjdk:8-jre")
     // Expose port 8080
     expose(8080)
 

--- a/examples/sbt-assembly/build.sbt
+++ b/examples/sbt-assembly/build.sbt
@@ -12,7 +12,7 @@ dockerfile in docker := {
   val artifactTargetPath = s"/app/${artifact.name}"
 
   new Dockerfile {
-    from("java")
+    from("openjdk:8-jre")
     add(artifact, artifactTargetPath)
     entryPoint("java", "-jar", artifactTargetPath)
   }

--- a/examples/sbt-native-packager/build.sbt
+++ b/examples/sbt-native-packager/build.sbt
@@ -12,7 +12,7 @@ dockerfile in docker := {
   val targetDir = "/app"
 
   new Dockerfile {
-    from("java")
+    from("openjdk:8-jre")
     entryPoint(s"$targetDir/bin/${executableScriptName.value}")
     copy(appDir, targetDir)
   }

--- a/src/main/scala/sbtdocker/immutable/Dockerfile.scala
+++ b/src/main/scala/sbtdocker/immutable/Dockerfile.scala
@@ -13,7 +13,7 @@ object Dockerfile {
  *  val jarFile: File
  *
  *  Dockerfile.empty
- *    .from("java")
+ *    .from("openjdk:8-jre")
  *    .add(jarFile, "/srv/app.jar")
  *    .workDir("/srv")
  *    .cmd("java", "-jar", "app.jar")

--- a/src/main/scala/sbtdocker/mutable/Dockerfile.scala
+++ b/src/main/scala/sbtdocker/mutable/Dockerfile.scala
@@ -9,7 +9,7 @@ import sbtdocker.{DockerfileLike, Instruction}
  *  val jarFile: File
  *
  *  new Dockerfile {
- *    from("java")
+ *    from("openjdk:8-jre")
  *    add(jarFile, "/srv/app.jar")
  *    workDir("/srv")
  *    cmd("java", "-jar", "app.jar")

--- a/src/sbt-test/sbt-docker/simple/build.sbt
+++ b/src/sbt-test/sbt-docker/simple/build.sbt
@@ -19,7 +19,7 @@ dockerfile in docker := {
   // Make a colon separated classpath with the JAR file
   val classpathString = files.values.mkString(":") + ":" + jarTarget
   new Dockerfile {
-    from("java")
+    from("openjdk:8-jre")
     // Add all files that is on the classpath
     files.foreach {
       case (source, destination) =>


### PR DESCRIPTION
This PR replaces the `java` base image with the image `openjdk:8-jre` wherever I could find it: https://hub.docker.com/r/library/openjdk/tags/8-jre/

Docker Hub says the `java` image is deprecated: https://hub.docker.com/_/java/

I have not run the examples in this repository to ensure the new base image still works.  The new base image has caused no problems for me in this project: https://github.com/peterbecich/BannoDemo/blob/master/build.sbt#L35

This tool has been useful to me.  Thanks!