### PR TITLE
Use a Dockerfile #56

### DIFF
--- a/examples/docker-from-file/Dockerfile
+++ b/examples/docker-from-file/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:8-jre
+
+ENTRYPOINT ["java", "-jar", "/root/example-sbt-assembly-assembly-0.1.0.jar"]
+
+ADD example-sbt-assembly-assembly-0.1.0.jar /root/example-sbt-assembly-assembly-0.1.0.jar
+

--- a/examples/docker-from-file/README.md
+++ b/examples/docker-from-file/README.md
@@ -1,0 +1,8 @@
+Example with docker-from-file
+=========================
+
+This example makes use of the [sbt-assembly](https://github.com/sbt/sbt-assembly) plugin to build a fat JAR file.
+
+Build a new image by running `sbt docker` in this directory.
+
+Then run the produced image with `docker run -i sbtdocker/example-sbt-assembly:v0.1.0`.

--- a/examples/docker-from-file/build.sbt
+++ b/examples/docker-from-file/build.sbt
@@ -1,0 +1,26 @@
+name := "example-sbt-assembly"
+
+organization := "sbtdocker"
+
+version := "0.1.0"
+
+enablePlugins(DockerFromFilePlugin)
+
+
+dockerFromFile in docker := {
+  val artifact: File = assembly.value
+
+  new DockerFromFile {
+    from(baseDirectory.value / "Dockerfile")
+    stageFile(artifact, "example-sbt-assembly-assembly-0.1.0.jar")
+  }
+}
+// Set names for the image
+imageNames in docker := Seq(
+  ImageName("sbtdocker/test:stable"),
+  ImageName(namespace = Some(organization.value),
+    repository = name.value,
+    tag = Some("v" + version.value))
+)
+
+buildOptions in docker := BuildOptions(cache = false)

--- a/examples/docker-from-file/project/assembly.sbt
+++ b/examples/docker-from-file/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")

--- a/examples/docker-from-file/project/build.properties
+++ b/examples/docker-from-file/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.18

--- a/examples/docker-from-file/project/project/ExampleBuild.scala
+++ b/examples/docker-from-file/project/project/ExampleBuild.scala
@@ -1,0 +1,6 @@
+import sbt._
+
+object ExampleBuild extends Build {
+  lazy val root = Project("example-sbt-assembly", file(".")) dependsOn docker
+  lazy val docker = file("../..").getAbsoluteFile.toURI
+}

--- a/examples/docker-from-file/src/main/scala/example/BasicExample.scala
+++ b/examples/docker-from-file/src/main/scala/example/BasicExample.scala
@@ -1,0 +1,10 @@
+package example
+
+import scala.concurrent.duration._
+
+object BasicExample extends App {
+  println("Application started")
+  println("Sleeping...")
+  Thread.sleep(2.seconds.toMillis)
+  println("Application exiting")
+}

--- a/src/main/scala/sbtdocker/DockerFromFileCommands.scala
+++ b/src/main/scala/sbtdocker/DockerFromFileCommands.scala
@@ -1,0 +1,30 @@
+package sbtdocker
+
+import sbt.File
+import sbtdocker.staging.CopyFile
+
+trait DockerFromFileInstructions extends DockerFromFileCommands {
+  type T <: DockerFromFileInstructions
+  def instructions: Seq[Instruction]
+}
+
+trait DockerFromFileCommands {
+  type T <: DockerFromFileCommands
+  def addInstruction(instruction: Instruction): T
+
+  /**
+    * Stage a file. The file will be copied to the stage directory when the Dockerfile is built.
+    *
+    *
+    * The `target` file must be unique for this Dockerfile. Otherwise later staged files will overwrite previous
+    * files on the same target.
+    *
+    * @param source File to copy into stage dir.
+    * @param target Path to copy file to, should be relative to the stage dir.
+    */
+  def stageFile(source: File, target: String): T
+  = addInstruction(Instructions.StageFiles(CopyFile(source), target))
+
+  def from(source: File): T
+  = addInstruction(Instructions.StageFiles(CopyFile(source), "Dockerfile"))
+}

--- a/src/main/scala/sbtdocker/DockerFromFilePlugin.scala
+++ b/src/main/scala/sbtdocker/DockerFromFilePlugin.scala
@@ -1,0 +1,13 @@
+package sbtdocker
+
+import sbt._
+
+object DockerFromFilePlugin extends AutoPlugin {
+
+  object autoImport {
+    val dockerFromFile = DockerKeys.dockerFromFile
+    type DockerFromFile =  sbtdocker.DockerFromFile
+  }
+
+  override def projectSettings = DockerSettings.dockerFromFileSettings
+}

--- a/src/main/scala/sbtdocker/DockerKeys.scala
+++ b/src/main/scala/sbtdocker/DockerKeys.scala
@@ -14,4 +14,5 @@ object DockerKeys {
   val imageNames = taskKey[Seq[ImageName]]("Names of the built image.")
   val dockerPath = settingKey[String]("Path to the Docker binary.")
   val buildOptions = settingKey[BuildOptions]("Options for the Docker build command.")
+  val dockerFromFile = taskKey[DockerFromFileInstructions]("Definition of the Docker text file.")
 }

--- a/src/main/scala/sbtdocker/Instructions.scala
+++ b/src/main/scala/sbtdocker/Instructions.scala
@@ -1,5 +1,7 @@
 package sbtdocker
 
+import java.io.File
+
 import org.apache.commons.lang3.StringEscapeUtils
 import sbtdocker.staging.SourceFile
 
@@ -19,6 +21,13 @@ trait DockerfileInstruction extends Instruction {
 
   @deprecated("Use toString instead.", "0.4.0")
   def toInstructionString = toString
+}
+
+trait ResourcesStagingInstruction extends Instruction {
+
+  def directory: File
+
+  def include: String
 }
 
 /**

--- a/src/main/scala/sbtdocker/immutable/DockerFromFile.scala
+++ b/src/main/scala/sbtdocker/immutable/DockerFromFile.scala
@@ -1,0 +1,15 @@
+package sbtdocker.immutable
+
+import sbtdocker.{DockerFromFileInstructions, Instruction}
+
+object DockerFromFile {
+  def empty = DockerFromFile()
+}
+
+case class DockerFromFile(instructions: Seq[Instruction] = Seq.empty) extends DockerFromFileInstructions {
+  override type T = DockerFromFile
+
+  override def addInstruction(instruction: Instruction) = DockerFromFile(instructions :+ instruction)
+
+  protected def self = this
+}

--- a/src/main/scala/sbtdocker/mutable/DockerFromFile.scala
+++ b/src/main/scala/sbtdocker/mutable/DockerFromFile.scala
@@ -1,0 +1,20 @@
+package sbtdocker.mutable
+
+import sbtdocker.{DockerFromFileInstructions, Instruction}
+
+case class DockerFromFile(var instructions: Seq[Instruction] = Seq.empty) extends DockerFromFileInstructions {
+  type T = DockerFromFile
+
+  def addInstruction(instruction: Instruction) = {
+    instructions :+= instruction
+    this
+  }
+
+  def addInstructions(instructions: TraversableOnce[Instruction]) = {
+    this.instructions ++= instructions
+    this
+  }
+
+  protected def self = this
+}
+

--- a/src/main/scala/sbtdocker/package.scala
+++ b/src/main/scala/sbtdocker/package.scala
@@ -5,6 +5,12 @@ package object sbtdocker {
   type ImmutableDockerfile = immutable.Dockerfile
   val ImmutableDockerfile = immutable.Dockerfile
 
+  val DockerFromFile = mutable.DockerFromFile
+  type DockerFromFile = mutable.DockerFromFile
+
+  type ImmutableDockerFromFile = immutable.DockerFromFile
+  val ImmutableDockerFromFile = immutable.DockerFromFile
+
   @deprecated("Use sbtdocker.Instructions.StageFiles", "1.0.0")
   type StageFile = Instructions.StageFiles
   @deprecated("Use sbtdocker.Instructions.StageFiles", "1.0.0")

--- a/src/main/scala/sbtdocker/staging/DefaultDockerFromFileProcessor.scala
+++ b/src/main/scala/sbtdocker/staging/DefaultDockerFromFileProcessor.scala
@@ -1,0 +1,12 @@
+package sbtdocker.staging
+
+import sbt._
+import sbtdocker._
+import sbtdocker.staging.DefaultDockerfileProcessor._
+
+object DefaultDockerFromFileProcessor extends DockerSourceFileProcessor {
+
+  def apply(dockerSourceFile: DockerFromFileInstructions, stageDir: File) = {
+    dockerSourceFile.instructions.foldLeft(StagedDockerfile.empty)(handleInstruction(stageDir))
+  }
+}

--- a/src/main/scala/sbtdocker/staging/DockerSourceFileProcessor.scala
+++ b/src/main/scala/sbtdocker/staging/DockerSourceFileProcessor.scala
@@ -1,0 +1,9 @@
+package sbtdocker.staging
+
+import java.io.File
+
+import sbtdocker.DockerFromFileInstructions
+
+trait DockerSourceFileProcessor {
+  def apply(dockerFromFile: DockerFromFileInstructions, stageDir: File): StagedDockerfile
+}

--- a/src/sbt-test/sbt-docker/docker-from-file/Dockerfile
+++ b/src/sbt-test/sbt-docker/docker-from-file/Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:8-jre
+
+COPY scala-library-2.11.5.jar /root/scala-library-2.11.5.jar
+
+COPY docker-from-file_2.11-0.1.0.jar /root/docker-from-file_2.11-0.1.0.jar
+
+CMD ["java", "-cp", "/root/*", "simple.Hello"]

--- a/src/sbt-test/sbt-docker/docker-from-file/build.sbt
+++ b/src/sbt-test/sbt-docker/docker-from-file/build.sbt
@@ -1,0 +1,42 @@
+enablePlugins(DockerFromFilePlugin)
+
+name := "docker-from-file"
+
+organization := "sbtdocker"
+
+version := "0.1.0"
+
+scalaVersion := "2.11.5"
+
+libraryDependencies += "joda-time" % "joda-time" % "2.7"
+
+dockerFromFile in docker := {
+  new DockerFromFile {
+    from(baseDirectory.value / "Dockerfile")
+    stageFile(target.value / "scala-2.11/docker-from-file_2.11-0.1.0.jar",
+      "docker-from-file_2.11-0.1.0.jar")
+    val appPath = "/app"
+    val libsPath = s"$appPath/libs/"
+    val classpath = Keys.managedClasspath.in(Compile).value
+    // add scala jar
+    val libPaths = classpath.files.filter(_.getName.contains("scala-library")).map { libFile =>
+      val toPath = file(libsPath) / libFile.name
+      stageFile(libFile, libFile.name)
+    }
+  }
+}
+
+imageNames in docker := Seq(
+  ImageName("sbtdocker/basic:stable"),
+  ImageName(namespace = Some(organization.value),
+    repository = name.value,
+    tag = Some("v" + version.value))
+)
+
+val check = taskKey[Unit]("Check")
+
+check := {
+  val process = Process("docker", Seq("run", "--rm", "sbtdocker/docker-from-file:v0.1.0"))
+  val out = process.!!
+  if (out.trim != "Hello Docker from text file") sys.error("Unexpected output: " + out)
+}

--- a/src/sbt-test/sbt-docker/docker-from-file/project/build.properties
+++ b/src/sbt-test/sbt-docker/docker-from-file/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.18

--- a/src/sbt-test/sbt-docker/docker-from-file/project/plugins.sbt
+++ b/src/sbt-test/sbt-docker/docker-from-file/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  sys.props.get("plugin.version") match {
+    case Some(v) =>
+      addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % v)
+    case None =>
+      sys.error("The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  }
+}

--- a/src/sbt-test/sbt-docker/docker-from-file/src/main/scala/simple/Hello.scala
+++ b/src/sbt-test/sbt-docker/docker-from-file/src/main/scala/simple/Hello.scala
@@ -1,0 +1,5 @@
+package simple
+
+object Hello extends App {
+  println("Hello Docker from text file")
+}

--- a/src/sbt-test/sbt-docker/docker-from-file/test
+++ b/src/sbt-test/sbt-docker/docker-from-file/test
@@ -1,0 +1,3 @@
+> docker
+$ exists target/docker/Dockerfile
+> check

--- a/src/test/scala/sbtdocker/immutable/ImmutableDockerFromFileSpec.scala
+++ b/src/test/scala/sbtdocker/immutable/ImmutableDockerFromFileSpec.scala
@@ -1,0 +1,37 @@
+package sbtdocker.immutable
+
+import org.scalatest.{FlatSpec, Matchers}
+import sbt.file
+import sbtdocker.Instructions.StageFiles
+import sbtdocker.staging.CopyFile
+
+class ImmutableDockerFromFileSpec extends FlatSpec with Matchers {
+
+  "DockerFromfile" should "be immutable" in {
+    val empty = DockerFromFile()
+    val nonEmpty = empty
+      .stageFile(file("/x"), "/")
+
+    empty should not equal nonEmpty
+  }
+
+  it should "have methods for all instructions" in {
+    val file1 = file("/1")
+    val file2 = file("/2")
+
+    val dockerFromFile = DockerFromFile.empty
+      .from(file1)
+      .stageFile(file2, "file2")
+
+    val sourceFile1 = CopyFile(file1)
+    val sourceFile2 = CopyFile(file2)
+
+
+    val instructions = Seq(
+      StageFiles(Seq(sourceFile1), "Dockerfile"),
+      StageFiles(Seq(sourceFile2), "file2"))
+
+    dockerFromFile.instructions should contain theSameElementsInOrderAs instructions
+  }
+
+}

--- a/src/test/scala/sbtdocker/mutable/MutableDockerFromFileSpec.scala
+++ b/src/test/scala/sbtdocker/mutable/MutableDockerFromFileSpec.scala
@@ -1,0 +1,45 @@
+package sbtdocker.mutable
+
+
+import org.scalatest.{FlatSpec, Matchers}
+import sbt._
+import sbtdocker.Instructions.StageFiles
+import sbtdocker.staging.CopyFile
+
+class MutableDockerFromFileSpec extends FlatSpec with Matchers {
+
+  "DockerFromFile" should "be mutable" in {
+    val file1 = file("/1")
+    val file2 = file("/2")
+    val dockerFromfile = new DockerFromFile()
+    dockerFromfile
+      .from(file1)
+      .stageFile(file2, "echo123")
+
+    val sourceFile1 = CopyFile(file1)
+    val sourceFile2 = CopyFile(file2)
+
+    dockerFromfile.instructions should contain theSameElementsInOrderAs
+      Seq(StageFiles(Seq(sourceFile1), "Dockerfile"), StageFiles(Seq(sourceFile2), "echo123"))
+  }
+
+  it should "have methods for all instructions" in {
+    val file1 = file("/1")
+    val file2 = file("/2")
+
+    val dockerFromfile = new DockerFromFile {
+      from(file1)
+      stageFile(file2, "echo123")
+    }
+
+    val sourceFile1 = CopyFile(file1)
+    val sourceFile2 = CopyFile(file2)
+
+    val instructions = Seq(
+      StageFiles(Seq(sourceFile1), "Dockerfile"),
+      StageFiles(Seq(sourceFile2), "echo123"))
+
+    dockerFromfile.instructions should contain theSameElementsInOrderAs instructions
+  }
+
+}

--- a/src/test/scala/sbtdocker/staging/DefaultDockerFromFileProcessorSpec.scala
+++ b/src/test/scala/sbtdocker/staging/DefaultDockerFromFileProcessorSpec.scala
@@ -1,0 +1,40 @@
+package sbtdocker.staging
+
+import org.scalatest.{FlatSpec, Matchers}
+import sbt.file
+import sbtdocker.ImmutableDockerFromFile
+import sbtdocker.Helpers._
+
+class DefaultDockerFromFileProcessorSpec extends FlatSpec with Matchers {
+  val stageDir = file("/tmp/staging")
+
+  "The default Dockerfile processor" should "handle file staging instructions" in {
+    val dockerSourcefile = ImmutableDockerFromFile.empty
+      .from(file("Dockerfile"))
+      .stageFile(file("/a/b/c"), "/b/c")
+
+    val stagedDockerfile = DefaultDockerFromFileProcessor(dockerSourcefile, stageDir)
+
+    stagedDockerfile.instructions shouldBe empty
+    stagedDockerfile.instructionsString shouldBe empty
+    stagedDockerfile.stageFiles should contain theSameElementsAs Seq(
+      CopyFile(file("/a/b/c")) -> (stageDir / "b" / "c"),
+      CopyFile(file("Dockerfile")) -> (stageDir / "Dockerfile")
+    )
+  }
+
+  it should "handle staging many files" in {
+    val dockerSourcefile = ImmutableDockerFromFile.empty
+      .stageFile(file("/a/b/c"), "/b/c")
+      .stageFile(file("dir"), "dir")
+      .stageFile(file("/other/file"), "/x/")
+
+    val stagedDockerfile = DefaultDockerFromFileProcessor(dockerSourcefile, stageDir)
+
+    stagedDockerfile.stageFiles should contain theSameElementsAs Seq(
+      CopyFile(file("/a/b/c")) -> (stageDir / "b" / "c"),
+      CopyFile(file("dir")) -> (stageDir / "dir"),
+      CopyFile(file("/other/file")) -> (stageDir / "x" / "file" )
+    )
+  }
+}


### PR DESCRIPTION
Here is my approach into using Dockerfile. My approach was to maintain `sbt docker`, `sbt dockerBuildAndPush` etc but required an additional plugin. Setting image names remains the same.

```scala
enablePlugins(DockerFromFilePlugin)

dockerFromFile in docker := {
  val artifact: File = assembly.value

  new DockerFromFile {
    from(baseDirectory.value / "Dockerfile")
    stageFile(artifact, "example-sbt-assembly-assembly-0.1.0.jar")
  }
}
```