### PR TITLE
Sanitize docker tag names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,17 @@ jdk:
   - oraclejdk9
   - oraclejdk11
   - openjdk7
+services: docker
 
 cache:
   directories:
     - $HOME/.m2
     - $HOME/.ivy2/cache
     - $HOME/.sbt
+
+script:
+  - sbt ++$TRAVIS_SCALA_VERSION test
+  - sbt ++$TRAVIS_SCALA_VERSION scripted
 
 before_cache:
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Only the ScalaTest tests will be run!
 # The scripted tests require Docker which travis does not support
 language: scala
+dist: trusty
 scala:
   - 2.10.7
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ scala:
   - 2.10.7
 jdk:
   - oraclejdk8
-  - oraclejdk9
-  - oraclejdk11
   - openjdk7
 services: docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,9 @@ scala:
   - 2.10.7
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - oraclejdk9
+  - oraclejdk11
   - openjdk7
-# Workaround for buffer overflow error in OpenJDK 7
-addons:
-  hosts:
-    - sbt-docker-ci
-  hostname: sbt-docker-ci
 
 cache:
   directories:

--- a/src/main/scala/sbtdocker/models.scala
+++ b/src/main/scala/sbtdocker/models.scala
@@ -14,6 +14,7 @@ object BuildOptions {
 
   }
 
+
   object Pull {
 
     sealed trait Option
@@ -52,7 +53,7 @@ object ImageName {
    * A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes.
    * A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
    */
-  val forbiddenTagCharacters = """[^a-zA-Z0-9_\-,]""".r
+  private val forbiddenTagCharacters = """[^a-zA-Z0-9_\-,]""".r
 
   /**
    * Parse a [[sbtdocker.ImageName]] from a string.
@@ -76,7 +77,7 @@ object ImageName {
 
     val (repo, tag) = repoAndTag.split(":", 2) match {
       case Array(r, t) =>
-        (r, Some(t))
+        (r, Some(ImageName.forbiddenTagCharacters.replaceAllIn(t, "-")))
       case Array(r) =>
         (r, None)
     }
@@ -103,14 +104,9 @@ case class ImageName(
   override def toString = {
     val registryString = registry.fold("")(_ + "/")
     val namespaceString = namespace.fold("")(_ + "/")
-    val tagString = sanitizedTagString.fold("")(":" + _)
+    val tagString = tag.fold("")(":" + _)
     registryString + namespaceString + repository + tagString
   }
-
-  private def sanitizedTagString = tag.map(s => {
-    val dashesForSlashes = s.replace('/', '-')
-    ImageName.forbiddenTagCharacters.replaceAllIn(dashesForSlashes, "")
-  })
 
   @deprecated("Use toString instead.", "0.4.0")
   def name = toString

--- a/src/test/scala/sbtdocker/ImageNameSpec.scala
+++ b/src/test/scala/sbtdocker/ImageNameSpec.scala
@@ -89,6 +89,6 @@ class ImageNameSpec extends FlatSpec with Matchers {
   }
 
   it should "sanitize bad tags" in {
-    ImageName(repository = "repo", tag = Some("än/Unu5u4|-tag")).toString shouldEqual "repo:-n-Unu5u4--tag"
+    ImageName("repo:än/Unu5u4|-tag").toString shouldEqual "repo:-n-Unu5u4--tag"
   }
 }

--- a/src/test/scala/sbtdocker/ImageNameSpec.scala
+++ b/src/test/scala/sbtdocker/ImageNameSpec.scala
@@ -89,6 +89,6 @@ class ImageNameSpec extends FlatSpec with Matchers {
   }
 
   it should "sanitize bad tags" in {
-    ImageName(repository = "repo", tag = Some("an/Unu5u4|-tag")).toString shouldEqual "repo:an-Unu5u4-tag"
+    ImageName(repository = "repo", tag = Some("än/Unu5u4|-tag")).toString shouldEqual "repo:-n-Unu5u4--tag"
   }
 }

--- a/src/test/scala/sbtdocker/ImageNameSpec.scala
+++ b/src/test/scala/sbtdocker/ImageNameSpec.scala
@@ -87,4 +87,8 @@ class ImageNameSpec extends FlatSpec with Matchers {
       repository = "test",
       tag = Some("v2")).toString shouldEqual "registry.example.com/sbtdocker/test:v2"
   }
+
+  it should "sanitize bad tags" in {
+    ImageName(repository = "repo", tag = Some("an/Unu5u4|-tag")).toString shouldEqual "repo:an-Unu5u4-tag"
+  }
 }


### PR DESCRIPTION
Docker tags are not allowed to contain certain characters. Docker tags might be based on e.g. git branch names which can contain those characters. It would be useful to sanitize the tags to not unnecessarily limit the naming freedom of future git branches.