### PR TITLE
Add support for build arguments (docker build's --build-arg)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,18 @@ buildOptions in docker := BuildOptions(
 )
 ```
 
+### Build arguments / `docker build`s `--build-arg`
+
+Use the key `buildArgs in docker` to set build args (see [documentation][build-arg-doc] on build args
+in docker)
+
+Example:
+```scala
+buildArgs in docker := Map(
+  "argName" -> "argValue"
+)
+```
+
 ### Auto packaging JVM applications
 
 If you have a standalone JVM application that you want a simple Docker image for.
@@ -177,3 +189,4 @@ Its very basic, so if you have more advanced needs then define your own Dockerfi
 [sbt]: http://www.scala-sbt.org/
 [sbt-assembly]: https://github.com/sbt/sbt-assembly
 [sbt-native-packager]: https://github.com/sbt/sbt-native-packager
+[build-arg-doc]: https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg

--- a/src/main/scala/sbtdocker/DockerKeys.scala
+++ b/src/main/scala/sbtdocker/DockerKeys.scala
@@ -14,4 +14,5 @@ object DockerKeys {
   val imageNames = taskKey[Seq[ImageName]]("Names of the built image.")
   val dockerPath = settingKey[String]("Path to the Docker binary.")
   val buildOptions = settingKey[BuildOptions]("Options for the Docker build command.")
+  val buildArgs = settingKey[Map[String, String]]("Build arguments (build-arg) for the Docker build command.")
 }

--- a/src/main/scala/sbtdocker/DockerPlugin.scala
+++ b/src/main/scala/sbtdocker/DockerPlugin.scala
@@ -13,6 +13,7 @@ object DockerPlugin extends AutoPlugin {
     val imageName = DockerKeys.imageName
     val imageNames = DockerKeys.imageNames
     val buildOptions = DockerKeys.buildOptions
+    val buildArgs = DockerKeys.buildArgs
 
     type Dockerfile = sbtdocker.Dockerfile
     val ImageId = sbtdocker.ImageId

--- a/src/main/scala/sbtdocker/DockerSettings.scala
+++ b/src/main/scala/sbtdocker/DockerSettings.scala
@@ -11,10 +11,11 @@ object DockerSettings {
       val log = Keys.streams.value.log
       val dockerPath = (DockerKeys.dockerPath in docker).value
       val buildOptions = (DockerKeys.buildOptions in docker).value
+      val buildArgs = (DockerKeys.buildArgs in docker).value
       val stageDir = (target in docker).value
       val dockerfile = (DockerKeys.dockerfile in docker).value
       val imageNames = (DockerKeys.imageNames in docker).value
-      DockerBuild(dockerfile, DefaultDockerfileProcessor, imageNames, buildOptions, stageDir, dockerPath, log)
+      DockerBuild(dockerfile, DefaultDockerfileProcessor, imageNames, buildOptions, stageDir, dockerPath, log, buildArgs)
     },
     dockerPush := {
       val log = Keys.streams.value.log
@@ -51,7 +52,8 @@ object DockerSettings {
       Seq((imageName in docker).value)
     },
     dockerPath in docker := sys.env.get("DOCKER").filter(_.nonEmpty).getOrElse("docker"),
-    buildOptions in docker := BuildOptions()
+    buildOptions in docker := BuildOptions(),
+    buildArgs in docker := Map.empty
   )
 
   def autoPackageJavaApplicationSettings(

--- a/src/sbt-test/sbt-docker/build-args/build.sbt
+++ b/src/sbt-test/sbt-docker/build-args/build.sbt
@@ -1,0 +1,35 @@
+import sbtdocker.DockerfileInstruction
+
+enablePlugins(DockerPlugin)
+
+name := "build-args-sample"
+
+organization := "sbtdocker"
+
+version := "0.1.0"
+
+buildArgs in docker := Map("person_to_greet" -> "world")
+
+// Define a Dockerfile
+dockerfile in docker := {
+  new Dockerfile {
+    from("busybox")
+    addInstruction(new DockerfileInstruction {
+      override def instructionName: String = "ARG"
+      override def arguments: String = "person_to_greet"
+    })
+    envRaw("PERSON_TO_GREET=$person_to_greet")
+    cmdRaw("""echo "Hello $PERSON_TO_GREET!"""")
+  }
+}
+
+val check = taskKey[Unit]("Check")
+
+check := {
+  val names = (imageNames in docker).value
+  names.foreach { imageName =>
+    val process = Process("docker", Seq("run", "--rm", imageName.toString))
+    val out = process.!!
+    if (out.trim != "Hello world!") sys.error("Unexpected output: " + out)
+  }
+}

--- a/src/sbt-test/sbt-docker/build-args/project/build.properties
+++ b/src/sbt-test/sbt-docker/build-args/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.18

--- a/src/sbt-test/sbt-docker/build-args/project/plugins.sbt
+++ b/src/sbt-test/sbt-docker/build-args/project/plugins.sbt
@@ -1,0 +1,9 @@
+{
+  sys.props.get("plugin.version") match {
+    case Some(v) =>
+      addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % v)
+    case None =>
+      sys.error("The system property 'plugin.version' is not defined. " +
+        "Specify this property using the scriptedLaunchOpts -D.")
+  }
+}

--- a/src/sbt-test/sbt-docker/build-args/test
+++ b/src/sbt-test/sbt-docker/build-args/test
@@ -1,0 +1,3 @@
+> docker
+$ exists target/docker/Dockerfile
+> check

--- a/src/test/scala/sbtdocker/DockerBuildSpec.scala
+++ b/src/test/scala/sbtdocker/DockerBuildSpec.scala
@@ -97,4 +97,10 @@ class DockerBuildSpec extends FreeSpec with Matchers {
       flags should contain("--pull=true")
     }
   }
+
+  "Build buildArgs" - {
+    "Simple build-arg" in {
+      DockerBuild.buildBuildArgs(Map("hello" -> "world")) shouldBe List("--build-arg", "hello=world")
+    }
+  }
 }


### PR DESCRIPTION
This is mostly useful for complex parent images (those using something like `ONBUILD ARG ...`) so there is only support for passing values of build arguments and not defining them