### PR TITLE
Return image name and id from dockerPush and dockerBuildAndPush

### DIFF
--- a/src/main/scala/sbtdocker/DockerKeys.scala
+++ b/src/main/scala/sbtdocker/DockerKeys.scala
@@ -4,8 +4,8 @@ import sbt._
 
 object DockerKeys {
   val docker = taskKey[ImageId]("Build a Docker image.")
-  val dockerBuildAndPush = taskKey[ImageId]("Build a Docker image and pushes it to a registry.")
-  val dockerPush = taskKey[Unit]("Push a already built Docker image to a registry.")
+  val dockerBuildAndPush = taskKey[Map[ImageName, ImageId]]("Build a Docker image and pushes it to a registry.")
+  val dockerPush = taskKey[Map[ImageName, ImageId]]("Push a already built Docker image to a registry.")
 
   @deprecated("Use imageNames instead.", "1.0.0")
   val imageName = taskKey[ImageName]("Name of the built image.")

--- a/src/main/scala/sbtdocker/DockerKeys.scala
+++ b/src/main/scala/sbtdocker/DockerKeys.scala
@@ -4,8 +4,8 @@ import sbt._
 
 object DockerKeys {
   val docker = taskKey[ImageId]("Build a Docker image.")
-  val dockerBuildAndPush = taskKey[Map[ImageName, ImageId]]("Build a Docker image and pushes it to a registry.")
-  val dockerPush = taskKey[Map[ImageName, ImageId]]("Push a already built Docker image to a registry.")
+  val dockerBuildAndPush = taskKey[Map[ImageName, ImageDigest]]("Build a Docker image and pushes it to a registry.")
+  val dockerPush = taskKey[Map[ImageName, ImageDigest]]("Push a already built Docker image to a registry.")
 
   @deprecated("Use imageNames instead.", "1.0.0")
   val imageName = taskKey[ImageName]("Name of the built image.")

--- a/src/main/scala/sbtdocker/DockerPush.scala
+++ b/src/main/scala/sbtdocker/DockerPush.scala
@@ -13,13 +13,10 @@ object DockerPush {
     * @param imageNames names of the images to push
     * @param log logger
     */
-  def apply(dockerPath: String, imageNames: Seq[ImageName], log: Logger): Map[ImageName, ImageId] = {
-    imageNames
-      .map { imageName =>
-        apply(dockerPath, imageName, log)
-      }
-      .flatten
-      .toMap
+  def apply(dockerPath: String, imageNames: Seq[ImageName], log: Logger): Map[ImageName, ImageDigest] = {
+    imageNames.map { imageName =>
+      apply(dockerPath, imageName, log)
+    }.toMap
   }
 
   /**
@@ -29,7 +26,7 @@ object DockerPush {
     * @param imageName name of the image to push
     * @param log logger
     */
-  def apply(dockerPath: String, imageName: ImageName, log: Logger): Map[ImageName, ImageId] = {
+  def apply(dockerPath: String, imageName: ImageName, log: Logger): (ImageName, ImageDigest) = {
     log.info(s"Pushing docker image with name: '$imageName'")
 
     var lines = Seq.empty[String]
@@ -54,12 +51,12 @@ object DockerPush {
     val PushedImageId = ".* sha256:([0-9a-f]+) .*".r
 
     val imageId = lines.collect {
-      case PushedImageId(id) => ImageId(id)
+      case PushedImageId(id) => ImageDigest(id)
     }.lastOption
 
     imageId match {
       case Some(id) =>
-        Map(imageName -> id)
+        imageName -> id
       case None =>
         throw new DockerPushException("Could not parse Docker image id")
     }

--- a/src/main/scala/sbtdocker/DockerPush.scala
+++ b/src/main/scala/sbtdocker/DockerPush.scala
@@ -48,7 +48,7 @@ object DockerPush {
     val exitValue = process ! processLog
     if (exitValue != 0) sys.error("Failed to push")
 
-    val PushedImageId = ".* sha256:([0-9a-f]+) .*".r
+    val PushedImageId = ".* digest: sha256:([0-9a-f]+) .*".r
 
     val imageId = lines.collect {
       case PushedImageId(id) => ImageDigest(id)

--- a/src/main/scala/sbtdocker/DockerPush.scala
+++ b/src/main/scala/sbtdocker/DockerPush.scala
@@ -48,10 +48,10 @@ object DockerPush {
     val exitValue = process ! processLog
     if (exitValue != 0) sys.error("Failed to push")
 
-    val PushedImageId = ".* digest: sha256:([0-9a-f]+) .*".r
+    val PushedImageDigestSha256 = ".* digest: sha256:([0-9a-f]+) .*".r
 
     val imageId = lines.collect {
-      case PushedImageId(id) => ImageDigest(id)
+      case PushedImageDigestSha256(digest) => ImageDigest("sha256", digest)
     }.lastOption
 
     imageId match {

--- a/src/main/scala/sbtdocker/DockerPush.scala
+++ b/src/main/scala/sbtdocker/DockerPush.scala
@@ -13,10 +13,13 @@ object DockerPush {
     * @param imageNames names of the images to push
     * @param log logger
     */
-  def apply(dockerPath: String, imageNames: Seq[ImageName], log: Logger): Unit = {
-    imageNames.foreach { imageName =>
-      apply(dockerPath, imageName, log)
-    }
+  def apply(dockerPath: String, imageNames: Seq[ImageName], log: Logger): Map[ImageName, ImageId] = {
+    imageNames
+      .map { imageName =>
+        apply(dockerPath, imageName, log)
+      }
+      .flatten
+      .toMap
   }
 
   /**
@@ -26,7 +29,7 @@ object DockerPush {
     * @param imageName name of the image to push
     * @param log logger
     */
-  def apply(dockerPath: String, imageName: ImageName, log: Logger): ImageId = {
+  def apply(dockerPath: String, imageName: ImageName, log: Logger): Map[ImageName, ImageId] = {
     log.info(s"Pushing docker image with name: '$imageName'")
 
     var lines = Seq.empty[String]
@@ -56,7 +59,7 @@ object DockerPush {
 
     imageId match {
       case Some(id) =>
-        id
+        Map(imageName -> id)
       case None =>
         throw new DockerPushException("Could not parse Docker image id")
     }

--- a/src/main/scala/sbtdocker/DockerPush.scala
+++ b/src/main/scala/sbtdocker/DockerPush.scala
@@ -50,15 +50,15 @@ object DockerPush {
 
     val PushedImageDigestSha256 = ".* digest: sha256:([0-9a-f]+) .*".r
 
-    val imageId = lines.collect {
+    val imageDigest = lines.collect {
       case PushedImageDigestSha256(digest) => ImageDigest("sha256", digest)
     }.lastOption
 
-    imageId match {
-      case Some(id) =>
-        imageName -> id
+    imageDigest match {
+      case Some(digest) =>
+        imageName -> digest
       case None =>
-        throw new DockerPushException("Could not parse Docker image id")
+        throw new DockerPushException("Could not parse Docker image digest")
     }
   }
 }

--- a/src/main/scala/sbtdocker/DockerSettings.scala
+++ b/src/main/scala/sbtdocker/DockerSettings.scala
@@ -26,10 +26,8 @@ object DockerSettings {
       DockerPush(dockerPath, imageNames, log)
     },
     dockerBuildAndPush := Def.taskDyn {
-      val id = docker.value
       Def.task {
         dockerPush.value
-        id
       }
     }.value,
     dockerfile in docker := {

--- a/src/main/scala/sbtdocker/DockerSettings.scala
+++ b/src/main/scala/sbtdocker/DockerSettings.scala
@@ -26,6 +26,7 @@ object DockerSettings {
       DockerPush(dockerPath, imageNames, log)
     },
     dockerBuildAndPush := Def.taskDyn {
+      docker.value
       Def.task {
         dockerPush.value
       }

--- a/src/main/scala/sbtdocker/models.scala
+++ b/src/main/scala/sbtdocker/models.scala
@@ -48,8 +48,8 @@ final case class ImageId(id: String) extends AnyVal {
 
 /**
   * The image digest, the format of the digest is `algorithm:hex-string`
-  * @param digest A digest of the image, as a string.
   * @param algorithm The algorithm used to produce the digest.
+  * @param digest A digest of the image, as a string.
   */
 final case class ImageDigest(algorithm: String, digest: String) {
   override def toString = s"$algorithm:$digest"

--- a/src/main/scala/sbtdocker/models.scala
+++ b/src/main/scala/sbtdocker/models.scala
@@ -32,7 +32,7 @@ object BuildOptions {
   * @param removeIntermediateContainers Remove intermediate containers after a build.
   * @param pullBaseImage Always attempts to pull a newer version of the base image.
   */
-case class BuildOptions(
+final case class BuildOptions(
   cache: Boolean = true,
   removeIntermediateContainers: BuildOptions.Remove.Option = BuildOptions.Remove.OnSuccess,
   pullBaseImage: BuildOptions.Pull.Option = BuildOptions.Pull.IfMissing
@@ -42,8 +42,16 @@ case class BuildOptions(
   * Id of an Docker image.
   * @param id Id as a hexadecimal digit string.
   */
-case class ImageId(id: String) {
+final case class ImageId(id: String) extends AnyVal {
   override def toString = id
+}
+
+/**
+  * SHA of the pushed docker image.
+  * @param digest A SHA 256 digest as a string.
+  */
+final case class ImageDigest(digest: String) extends AnyVal {
+  override def toString = digest
 }
 
 object ImageName {
@@ -88,7 +96,7 @@ object ImageName {
   * @param namespace Namespace name.
   * @param tag Tag, for example a version number.
   */
-case class ImageName(
+final case class ImageName(
   registry: Option[String] = None,
   namespace: Option[String] = None,
   repository: String,

--- a/src/main/scala/sbtdocker/models.scala
+++ b/src/main/scala/sbtdocker/models.scala
@@ -47,11 +47,12 @@ final case class ImageId(id: String) extends AnyVal {
 }
 
 /**
-  * SHA of the pushed docker image.
-  * @param digest A SHA 256 digest as a string.
+  * The image digest, the format of the digest is `algorithm:hex-string`
+  * @param digest A digest of the image, as a string.
+  * @param algorithm The algorithm used to produce the digest.
   */
-final case class ImageDigest(digest: String) extends AnyVal {
-  override def toString = digest
+final case class ImageDigest(algorithm: String, digest: String) {
+  override def toString = s"$algorithm:$digest"
 }
 
 object ImageName {


### PR DESCRIPTION
This PR fixes issue #108 

In short, the PR changes the return types of `dockerBuildAndPush` and `dockerPush` to return a `Map[String,ImageId]` instead. 

This information is very useful for post build/push operations.

 