### PR TITLE
SuccessfullyBuiltBuildKit regex should match a word boundary before 'done' (rather than a literal backspace)

### DIFF
--- a/src/main/scala/sbtdocker/DockerBuild.scala
+++ b/src/main/scala/sbtdocker/DockerBuild.scala
@@ -86,7 +86,7 @@ object DockerBuild {
   }
 
   private val SuccessfullyBuilt = "^Successfully built ([0-9a-f]+)$".r
-  private val SuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\bdone$".r
+  private val SuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\\bdone$".r
 
   private[sbtdocker] def buildAndTag(
     imageNames: Seq[ImageName],


### PR DESCRIPTION
Followup to PR #119 

```
Welcome to Scala 2.13.4 (OpenJDK 64-Bit Server VM, Java 15.0.1).
Type in expressions for evaluation. Or try :help.

scala> val SuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\bdone$".r
val SuccessfullyBuiltBuildKit: scala.util.matching.Regex = .* writing image sha256:([0-9a-f]+) .*?done$

scala> val testInput = "#24 writing image sha256:06cadfa7a306e7fa32962929142b1a6297f78df6e26623d4bd9139d72e7bfc32 0.0s done"
val testInput: String = #24 writing image sha256:06cadfa7a306e7fa32962929142b1a6297f78df6e26623d4bd9139d72e7bfc32 0.0s done

scala> SuccessfullyBuiltBuildKit.findFirstMatchIn(testInput).get.group(1)
java.util.NoSuchElementException: None.get
  at scala.None$.get(Option.scala:627)
  at scala.None$.get(Option.scala:626)
  ... 32 elided

scala> val escapedSuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\\bdone$".r
val escapedSuccessfullyBuiltBuildKit: scala.util.matching.Regex = .* writing image sha256:([0-9a-f]+) .*\bdone$

scala> escapedSuccessfullyBuiltBuildKit.findFirstMatchIn(testInput).get.group(1)
val res1: String = 06cadfa7a306e7fa32962929142b1a6297f78df6e26623d4bd9139d72e7bfc32
```