### PR TITLE
Support nerdctl

### DIFF
--- a/src/main/scala/sbtdocker/DockerBuild.scala
+++ b/src/main/scala/sbtdocker/DockerBuild.scala
@@ -184,19 +184,16 @@ object DockerBuild {
           "--rm=true"
       }
     }
-    val pullFlag = {
-      val value = buildOptions.pullBaseImage match {
-        case BuildOptions.Pull.Always => true
-        case BuildOptions.Pull.IfMissing => false
-      }
-      "--pull=" + value
+    val pullFlag = buildOptions.pullBaseImage match {
+      case BuildOptions.Pull.Always => List("--pull")
+      case BuildOptions.Pull.IfMissing => Nil
     }
     val platformsFlag: List[String] = buildOptions.platforms match {
       case Seq() => Nil
       case platforms => List(s"--platform=${platforms.mkString(",")}")
     }
 
-    cacheFlag :: removeFlag :: pullFlag :: platformsFlag ::: buildOptions.additionalArguments.toList
+    cacheFlag :: removeFlag :: pullFlag ::: platformsFlag ::: buildOptions.additionalArguments.toList
   }
 
   private val SuccessfullyBuilt = "^Successfully built ([0-9a-f]+)$".r

--- a/src/main/scala/sbtdocker/DockerBuild.scala
+++ b/src/main/scala/sbtdocker/DockerBuild.scala
@@ -200,6 +200,7 @@ object DockerBuild {
   private val SuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltBuildx = ".* exporting config sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltPodman = "^([0-9a-f]{64})$".r
+  private val SuccessfullyBuiltNerdctl = "^Loaded image: .*sha256:([0-9a-f]+)$".r
 
   private[sbtdocker] def parseImageId(lines: Seq[String]): Option[ImageId] = {
     lines.collect {
@@ -207,6 +208,7 @@ object DockerBuild {
       case SuccessfullyBuiltBuildKit(id) => ImageId(id)
       case SuccessfullyBuiltBuildx(id) => ImageId(id)
       case SuccessfullyBuiltPodman(id) => ImageId(id)
+      case SuccessfullyBuiltNerdctl(id) => ImageId(id)
     }.lastOption
   }
 }

--- a/src/test/scala/sbtdocker/DockerBuildSpec.scala
+++ b/src/test/scala/sbtdocker/DockerBuildSpec.scala
@@ -67,7 +67,7 @@ class DockerBuildSpec extends AnyFreeSpec with Matchers {
 
       val flags = DockerBuild.generateBuildOptionFlags(options)
 
-      flags should contain theSameElementsAs Seq("--no-cache=false", "--pull=false", "--rm=true")
+      flags should contain theSameElementsAs Seq("--no-cache=false", "--rm=true")
     }
 
     "No cache" in {
@@ -88,14 +88,14 @@ class DockerBuildSpec extends AnyFreeSpec with Matchers {
       val options = BuildOptions(removeIntermediateContainers = BuildOptions.Remove.Never)
       val flags = DockerBuild.generateBuildOptionFlags(options)
 
-      flags should contain("--pull=false")
+      flags should contain("--rm=false")
     }
 
     "Always pull" in {
       val options = BuildOptions(pullBaseImage = BuildOptions.Pull.Always)
       val flags = DockerBuild.generateBuildOptionFlags(options)
 
-      flags should contain("--pull=true")
+      flags should contain("--pull")
     }
 
     "Add platform argument for cross build" in {


### PR DESCRIPTION
+ Fix "unknown flag: --pull" when run with nerdctl
Reason: [nerdctl](https://github.com/containerd/nerdctl) don't support `--pull` option
Changes: If `buildOptions.pullBaseImage == Pull.IfMissing` (default) then we omit this flag
+ Fix the imageId extracting logic from build log when run with nertctl