### PR TITLE
Parse Image Correctly When Using Containerd Image Store

### DIFF
--- a/src/main/scala/sbtdocker/DockerBuild.scala
+++ b/src/main/scala/sbtdocker/DockerBuild.scala
@@ -198,6 +198,7 @@ object DockerBuild {
 
   private val SuccessfullyBuilt = "^Successfully built ([0-9a-f]+)$".r
   private val SuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\\bdone$".r
+  private val SuccessfullyBuiltContainerd = ".* exporting manifest list sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltBuildx = ".* exporting config sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltPodman = "^([0-9a-f]{64})$".r
   private val SuccessfullyBuiltNerdctl = "^Loaded image: .*sha256:([0-9a-f]+)$".r
@@ -206,6 +207,7 @@ object DockerBuild {
     lines.collect {
       case SuccessfullyBuilt(id) => ImageId(id)
       case SuccessfullyBuiltBuildKit(id) => ImageId(id)
+      case SuccessfullyBuiltContainerd(id) => ImageId(id)
       case SuccessfullyBuiltBuildx(id) => ImageId(id)
       case SuccessfullyBuiltPodman(id) => ImageId(id)
       case SuccessfullyBuiltNerdctl(id) => ImageId(id)

--- a/src/test/scala/sbtdocker/DockerBuildSpec.scala
+++ b/src/test/scala/sbtdocker/DockerBuildSpec.scala
@@ -125,6 +125,18 @@ class DockerBuildSpec extends AnyFreeSpec with Matchers {
       DockerBuild.parseImageId(lines) shouldEqual Some(ImageId("353fcb84af6b"))
     }
 
+    "Docker build with containerd output" in {
+      val lines = Seq(
+        "[info] #10 exporting layers 2.8s done",
+        "[info] #10 exporting manifest sha256:7f8c52951645245ac6bdc0e213330a88834ebcce340b32a834287bb6bfa6d5cb 0.0s done",
+        "[info] #10 exporting config sha256:9f7f478055830d4b6f0981b76dcb33be52c1ef1496c71b2dbbecf7336ede58a2 0.0s done",
+        "[info] #10 exporting attestation manifest sha256:ba07dabd29c79fa4f8f55b2d691cc740638e4b4d6abe6eb07aa8774f0b203cc1",
+        "[info] #10 exporting attestation manifest sha256:ba07dabd29c79fa4f8f55b2d691cc740638e4b4d6abe6eb07aa8774f0b203cc1 0.1s done",
+        "[info] #10 exporting manifest list sha256:bb462cb506fd951efc8847f7f4c9a227b5908246101c1d9e5685daf632ce9c51 0.0s done"
+      )
+      DockerBuild.parseImageId(lines) shouldEqual Some(ImageId("bb462cb506fd951efc8847f7f4c9a227b5908246101c1d9e5685daf632ce9c51"))
+    }
+
     "Docker buildx output" in {
       val lines = Seq(
         "#7 exporting layers 0.4s done",


### PR DESCRIPTION
Hey Marcus, how are you?

I found an issue about building image when `containerd` is enabled for image store (needed for building multi-platform images).  Seems that images needs to be parsed slightly differently in this case. 

The way to reproduce it on my linux machine is to 

1. Enable containerd image store (Following https://docs.docker.com/storage/containerd/)
2. Build a random image (with or without specifying multiple platforms)

It should report something like 
```
[info] Tagging image 9f7f478055830d4b6f0981b76dcb33be52c1ef1496c71b2dbbecf7336ede58a2 with name: test-name
[info] Error response from daemon: No such image: sha256:9f7f478055830d4b6f0981b76dcb33be52c1ef1496c71b2dbbecf7336ede58a2
```

The follow commit should fix it,  please see tests for the output from docker deamon. Thanks!