### PR TITLE
Add support to build using containerd

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,8 @@ lazy val root = (project in file("."))
   )
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.11" % "test",
-  "org.apache.commons" % "commons-lang3" % "3.12.0"
+  "org.scalatest" %% "scalatest" % "3.2.19" % "test",
+  "org.apache.commons" % "commons-text" % "1.12.0"
 )
 
 scalacOptions := Seq("-deprecation", "-unchecked", "-feature")

--- a/src/main/scala/sbtdocker/DockerBuild.scala
+++ b/src/main/scala/sbtdocker/DockerBuild.scala
@@ -201,6 +201,7 @@ object DockerBuild {
   private val SuccessfullyBuiltBuildx = ".* exporting config sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltPodman = "^([0-9a-f]{64})$".r
   private val SuccessfullyBuiltNerdctl = "^Loaded image: .*sha256:([0-9a-f]+)$".r
+  private val SuccessfullyBuiltContainerd = ".* unpacking to moby-dangling@sha256:([0-9a-f]+) .*\\bdone$".r
 
   private[sbtdocker] def parseImageId(lines: Seq[String]): Option[ImageId] = {
     lines.collect {
@@ -209,6 +210,7 @@ object DockerBuild {
       case SuccessfullyBuiltBuildx(id) => ImageId(id)
       case SuccessfullyBuiltPodman(id) => ImageId(id)
       case SuccessfullyBuiltNerdctl(id) => ImageId(id)
+      case SuccessfullyBuiltContainerd(id) => ImageId(id)
     }.lastOption
   }
 }

--- a/src/main/scala/sbtdocker/DockerSettings.scala
+++ b/src/main/scala/sbtdocker/DockerSettings.scala
@@ -42,13 +42,11 @@ object DockerSettings {
         """.stripMargin)
     },
     docker / target := target.value / "docker",
-    docker / imageName := {
+    docker / imageNames := {
       val organisation = Option(Keys.organization.value).filter(_.nonEmpty)
       val name = Keys.normalizedName.value
-      ImageName(namespace = organisation, repository = name)
-    },
-    docker / imageNames := {
-      Seq((docker / imageName).value)
+      val imageName = ImageName(namespace = organisation, repository = name)
+      Seq(imageName)
     },
     docker / dockerPath := sys.env.get("DOCKER").filter(_.nonEmpty).getOrElse("docker"),
     docker / buildOptions := BuildOptions(),
@@ -68,7 +66,7 @@ object DockerSettings {
       (docker / Keys.mainClass).or(Compile / Keys.packageBin / Keys.mainClass).value
     },
     docker / dockerfile := {
-      val maybeMainClass = Keys.mainClass.in(docker).value
+      val maybeMainClass = (docker / Keys.mainClass).value
       maybeMainClass match {
         case None =>
           sys.error(

--- a/src/main/scala/sbtdocker/DockerTag.scala
+++ b/src/main/scala/sbtdocker/DockerTag.scala
@@ -21,7 +21,7 @@ object DockerTag {
     val command = dockerPath :: "tag" :: id.id :: name.toString :: Nil
     log.debug(s"Running command: '${command.mkString(" ")}'")
 
-    val processOutput = Process(command).lines(processLogger)
+    val processOutput = Process(command).lineStream(processLogger)
     processOutput.foreach { line =>
       log.info(line)
     }

--- a/src/main/scala/sbtdocker/DockerTag.scala
+++ b/src/main/scala/sbtdocker/DockerTag.scala
@@ -19,6 +19,7 @@ object DockerTag {
     log.info(s"Tagging image $id with name: $name")
 
     val command = dockerPath :: "tag" :: id.id :: name.toString :: Nil
+    log.debug(s"Running command: '${command.mkString(" ")}'")
 
     val processOutput = Process(command).lines(processLogger)
     processOutput.foreach { line =>

--- a/src/main/scala/sbtdocker/Instructions.scala
+++ b/src/main/scala/sbtdocker/Instructions.scala
@@ -1,6 +1,6 @@
 package sbtdocker
 
-import org.apache.commons.lang3.StringEscapeUtils
+import org.apache.commons.text.StringEscapeUtils
 import sbtdocker.staging.SourceFile
 
 import scala.concurrent.duration.FiniteDuration

--- a/src/test/scala/sbtdocker/DockerBuildSpec.scala
+++ b/src/test/scala/sbtdocker/DockerBuildSpec.scala
@@ -148,6 +148,21 @@ class DockerBuildSpec extends AnyFreeSpec with Matchers {
       DockerBuild.parseImageId(lines) shouldEqual Some(ImageId("688f3de768e18bed863a7357e48b3d11a546ec2064cbcce2ffbe63343525a3a0"))
     }
 
+    "Docker build output with containerd enabled" in {
+      val lines = Seq(
+        "#6 exporting to image",
+        "#6 exporting layers done",
+        "#6 exporting manifest sha256:beab5e36974d6ddfd65cfd0f8fda6283c5bb80ddded4b15f4e237fa255d38d18 done",
+        "#6 exporting config sha256:d8526f6dc6b4563ab8cebb8d27d5b58b75ef7f1be79e0407e543d2a115c4d778 done",
+        "#6 exporting attestation manifest sha256:51bacaed02635c5a0c3773d949583cae2452f68194b351335000befa3efda057 done",
+        "#6 exporting manifest list sha256:4df93e677e2cdf30b65bd92709eab5524c4014a9e022e6f876d151e37cd5d412 done",
+        "#6 naming to moby-dangling@sha256:4df93e677e2cdf30b65bd92709eab5524c4014a9e022e6f876d151e37cd5d412 done",
+        "#6 unpacking to moby-dangling@sha256:4df93e677e2cdf30b65bd92709eab5524c4014a9e022e6f876d151e37cd5d412 done",
+        "#6 DONE 0.0s"
+      )
+      DockerBuild.parseImageId(lines) shouldEqual Some(ImageId("4df93e677e2cdf30b65bd92709eab5524c4014a9e022e6f876d151e37cd5d412"))
+    }
+
     "Podman build output" in {
       val lines = Seq(
         "--> dada5485d85",


### PR DESCRIPTION
Fixes incorrect ImageId parsing when usage of containerd is enabled on docker desktop

<img width="656" alt="image" src="https://github.com/user-attachments/assets/139aed6e-db11-4322-8e2c-562ce6019649">
