### PR TITLE
Handle case where a dangling image is built, and an older SHA is matched during a docker build

### DIFF
--- a/src/main/scala/sbtdocker/DockerBuild.scala
+++ b/src/main/scala/sbtdocker/DockerBuild.scala
@@ -198,6 +198,7 @@ object DockerBuild {
 
   private val SuccessfullyBuilt = "^Successfully built ([0-9a-f]+)$".r
   private val SuccessfullyBuiltBuildKit = ".* writing image sha256:([0-9a-f]+) .*\\bdone$".r
+  private val SuccessfullyBuiltBuildxDangling = ".* naming to moby-dangling@sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltBuildx = ".* exporting config sha256:([0-9a-f]+) .*\\bdone$".r
   private val SuccessfullyBuiltPodman = "^([0-9a-f]{64})$".r
   private val SuccessfullyBuiltNerdctl = "^Loaded image: .*sha256:([0-9a-f]+)$".r
@@ -206,6 +207,7 @@ object DockerBuild {
     lines.collect {
       case SuccessfullyBuilt(id) => ImageId(id)
       case SuccessfullyBuiltBuildKit(id) => ImageId(id)
+      case SuccessfullyBuiltBuildxDangling(id) => ImageId(id)
       case SuccessfullyBuiltBuildx(id) => ImageId(id)
       case SuccessfullyBuiltPodman(id) => ImageId(id)
       case SuccessfullyBuiltNerdctl(id) => ImageId(id)


### PR DESCRIPTION
I have a problem where the buildAndTag function is failing. It succeeds to build, but fails to tag, because the image ID is not extracted correctly (in my case), because an older SHA is being matched.

My docker buildx version is:
`github.com/docker/buildx v0.16.2-desktop.1 081c21b9e461293ae243a1ff813a680a4f5f8fb9=`

The command that gets run is this:
`docker buildx build --no-cache=false --rm=true --platform=linux/amd64 --progress=plain --load --file Dockerfile target/docker`

This is the output I get:
```
#0 building with "desktop-linux" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 261B done
#1 DONE 0.0s

#2 [internal] load metadata for <image:4.0.0>
#2 ...

#3 [auth] <url>:pull token for eu.gcr.io
#3 DONE 0.0s

#2 [internal] load metadata for <image:4.0.0>
#2 DONE 4.3s

#4 [internal] load .dockerignore
#4 transferring context: 2B 0.0s done
#4 DONE 0.0s

#5 [internal] load build context
#5 transferring context: 2.51kB done
#5 DONE 0.0s

#6 [1/3] FROM <image:4.0.0>@sha256:074de1b5f1c5d8714095619cdbaf524afe5178c50cfb5a283355ae5baaebda81
#6 resolve <image:4.0.0>@sha256:074de1b5f1c5d8714095619cdbaf524afe5178c50cfb5a283355ae5baaebda81 0.0s done
#6 DONE 0.0s

#7 [2/3] ADD <COMMAND>
#7 CACHED

#8 [3/3] ADD <COMMAND>
#8 CACHED

#9 exporting to image
#9 exporting layers done
#9 exporting manifest sha256:d4842f736055a05328fc9310ee9a282258f273728a00518a782d50605f48a13d done
#9 exporting config sha256:66bc1b6b9618eb32bee7e7acbf220ef6d8481b0f3f5f46c8103999fc38510c8f done
#9 exporting attestation manifest sha256:2ff9ad2515bb51ce65584d75948e0d2180823ef1c422c9e40b4b1766623aa67e done
#9 exporting manifest list sha256:bae3d656704c64b00a0f09a28d6cd8c811c0e49df926d98c33265a5bc2d4555c done
#9 naming to moby-dangling@sha256:bae3d656704c64b00a0f09a28d6cd8c811c0e49df926d98c33265a5bc2d4555c done
#9 DONE 0.0s
```
sbt-docker then matches on the older "exporting config sha256" string instead of "naming to moby-dangling@sha256" string.